### PR TITLE
fix unable to open database

### DIFF
--- a/storage/database/badger_database.go
+++ b/storage/database/badger_database.go
@@ -160,6 +160,9 @@ func DefaultBadgerOptions(dir string) badger.Options {
 	// Don't cache blocks in memory. All reads should go to disk.
 	opts.BlockCacheSize = DefaultBlockCacheSize
 
+	//https://github.com/dgraph-io/badger/issues/1353
+	opts.Truncate = true
+
 	return opts
 }
 


### PR DESCRIPTION
## fix unable to open database

### Motivation
```
badger 2022/02/16 03:40:15 INFO: All 6 tables opened in 1.363s
badger 2022/02/16 03:40:15 INFO: Replaying file id: 46 at offset: 17321025
badger 2022/02/16 03:40:16 INFO: [Compactor: 0] Running compaction: {level:1 score:1.0013011395931244 dropPrefixes:[]} for level: 1
badger 2022/02/16 03:40:18 WARNING: Truncate Needed. File /data/mainnet/check-data/60a5748dd7f8da0a76c89a122db470212216e7e5654bbbcb8b8940ec103bc403/000046.vlog size: 46411776 Endoffset: 46409207
```

### Solution
[https://github.com/dgraph-io/badger/issues/1353](https://github.com/dgraph-io/badger/issues/1353)

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
