### PR TITLE
Add a new asserter client with ignoring rosetta spec validation.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 Coinbase, Inc.
+   Copyright 2024 Coinbase, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/asserter/account.go
+++ b/asserter/account.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asserter/account_test.go
+++ b/asserter/account_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asserter/asserter.go
+++ b/asserter/asserter.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asserter/asserter.go
+++ b/asserter/asserter.go
@@ -294,9 +294,9 @@ func NewClientWithOptions(
 	return asserter, nil
 }
 
-// NewClientWithoutRosettaSpec constructs a new Asserter using the provided
+// NewGenericRosettaClient constructs a new Asserter using the provided
 // arguments and without a Rosetta Spec validation. This is used to ignore rosetta spec validation
-func NewClientWithoutRosettaSpec(
+func NewGenericRosettaClient(
 	network *types.NetworkIdentifier,
 	genesisBlockIdentifier *types.BlockIdentifier,
 ) (*Asserter, error) {
@@ -325,12 +325,8 @@ func NewClientWithoutRosettaSpec(
 		ignoreRosettaSpecValidation: true,
 	}
 
-	asserter.operationStatusMap = map[string]bool{}
-	asserter.operationStatusMap["SUCCESS"] = true
-	asserter.operationStatusMap["OK"] = true
-	asserter.operationStatusMap["COMPLETED"] = true
-	asserter.operationStatusMap["FAILED"] = false
-	asserter.operationStatusMap["FAILURE"] = false
+	//init default operation statuses for generic rosetta client
+	InitOperationStatus(asserter)
 
 	return asserter, nil
 }

--- a/asserter/asserter.go
+++ b/asserter/asserter.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path"
+	"strings"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
 )
@@ -35,11 +36,12 @@ type Asserter struct {
 	timestampStartIndex int64
 
 	// These variables are used for request assertion.
-	historicalBalanceLookup bool
-	supportedNetworks       []*types.NetworkIdentifier
-	callMethods             map[string]struct{}
-	mempoolCoins            bool
-	validations             *Validations
+	historicalBalanceLookup     bool
+	supportedNetworks           []*types.NetworkIdentifier
+	callMethods                 map[string]struct{}
+	mempoolCoins                bool
+	validations                 *Validations
+	ignoreRosettaSpecValidation bool
 }
 
 // Validations is used to define stricter validations
@@ -292,6 +294,47 @@ func NewClientWithOptions(
 	return asserter, nil
 }
 
+// NewClientWithoutRosettaSpec constructs a new Asserter using the provided
+// arguments and without a Rosetta Spec validation. This is used to ignore rosetta spec validation
+func NewClientWithoutRosettaSpec(
+	network *types.NetworkIdentifier,
+	genesisBlockIdentifier *types.BlockIdentifier,
+) (*Asserter, error) {
+	if err := NetworkIdentifier(network); err != nil {
+		return nil, fmt.Errorf(
+			"network identifier %s is invalid: %w",
+			types.PrintStruct(network),
+			err,
+		)
+	}
+
+	if err := BlockIdentifier(genesisBlockIdentifier); err != nil {
+		return nil, fmt.Errorf(
+			"genesis block identifier %s is invalid: %w",
+			types.PrintStruct(genesisBlockIdentifier),
+			err,
+		)
+	}
+
+	asserter := &Asserter{
+		network:      network,
+		genesisBlock: genesisBlockIdentifier,
+		validations: &Validations{
+			Enabled: false,
+		},
+		ignoreRosettaSpecValidation: true,
+	}
+
+	asserter.operationStatusMap = map[string]bool{}
+	asserter.operationStatusMap["SUCCESS"] = true
+	asserter.operationStatusMap["OK"] = true
+	asserter.operationStatusMap["COMPLETED"] = true
+	asserter.operationStatusMap["FAILED"] = false
+	asserter.operationStatusMap["FAILURE"] = false
+
+	return asserter, nil
+}
+
 // ClientConfiguration returns all variables currently set in an Asserter.
 // This function will error if it is called on an uninitialized asserter.
 func (a *Asserter) ClientConfiguration() (*Configuration, error) {
@@ -336,7 +379,10 @@ func (a *Asserter) OperationSuccessful(operation *types.Operation) (bool, error)
 
 	val, ok := a.operationStatusMap[*operation.Status]
 	if !ok {
-		return false, fmt.Errorf("operation status %s is not found", *operation.Status)
+		val, ok = a.operationStatusMap[strings.ToUpper(*operation.Status)]
+		if !ok {
+			return false, fmt.Errorf("operation status %s is not found", *operation.Status)
+		}
 	}
 
 	return val, nil

--- a/asserter/asserter_test.go
+++ b/asserter/asserter_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asserter/block.go
+++ b/asserter/block.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asserter/block.go
+++ b/asserter/block.go
@@ -160,7 +160,7 @@ func (a *Asserter) OperationStatus(status *string, construction bool) error {
 		return ErrOperationStatusNotEmptyForConstruction
 	}
 
-	if _, ok := a.operationStatusMap[*status]; !ok {
+	if _, ok := a.operationStatusMap[*status]; !a.ignoreRosettaSpecValidation && !ok {
 		return fmt.Errorf("operation status %s is invalid: %w", *status, ErrOperationStatusInvalid)
 	}
 
@@ -174,7 +174,7 @@ func (a *Asserter) OperationType(t string) error {
 		return ErrAsserterNotInitialized
 	}
 
-	if t == "" || !containsString(a.operationTypes, t) {
+	if t == "" || (!a.ignoreRosettaSpecValidation && !containsString(a.operationTypes, t)) {
 		return fmt.Errorf("operation type %s is invalid: %w", t, ErrOperationTypeInvalid)
 	}
 
@@ -610,7 +610,7 @@ func (a *Asserter) Block(
 
 	// Only check for timestamp validity if timestamp start index is <=
 	// the current block index.
-	if a.timestampStartIndex <= block.BlockIdentifier.Index {
+	if !a.ignoreRosettaSpecValidation && a.timestampStartIndex <= block.BlockIdentifier.Index {
 		if err := Timestamp(block.Timestamp); err != nil {
 			return fmt.Errorf("timestamp %d is invalid: %w", block.Timestamp, err)
 		}

--- a/asserter/block_test.go
+++ b/asserter/block_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asserter/coin.go
+++ b/asserter/coin.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asserter/coin_test.go
+++ b/asserter/coin_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asserter/construction.go
+++ b/asserter/construction.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asserter/construction_test.go
+++ b/asserter/construction_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asserter/error.go
+++ b/asserter/error.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asserter/error.go
+++ b/asserter/error.go
@@ -33,6 +33,10 @@ func (a *Asserter) Error(
 		return err
 	}
 
+	if a.ignoreRosettaSpecValidation {
+		return nil
+	}
+
 	val, ok := a.errorTypeMap[err.Code]
 	if !ok {
 		return fmt.Errorf(

--- a/asserter/error_test.go
+++ b/asserter/error_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asserter/errors.go
+++ b/asserter/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asserter/errors_test.go
+++ b/asserter/errors_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asserter/events.go
+++ b/asserter/events.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asserter/events_test.go
+++ b/asserter/events_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asserter/mempool.go
+++ b/asserter/mempool.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asserter/network.go
+++ b/asserter/network.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asserter/network_test.go
+++ b/asserter/network_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asserter/operation_status.go
+++ b/asserter/operation_status.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asserter/operation_status.go
+++ b/asserter/operation_status.go
@@ -1,0 +1,34 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package asserter
+
+const (
+	OperationStatusSuccess   = "SUCCESS"
+	OperationStatusOk        = "OK"
+	OperationStatusCompleted = "COMPLETED"
+	OperationStatusFailed    = "FAILED"
+	OperationStatusFailure   = "FAILURE"
+)
+
+// InitOperationStatus initializes operation status map for a generic rosetta client
+func InitOperationStatus(asserter *Asserter) {
+	asserter.operationStatusMap = map[string]bool{
+		OperationStatusSuccess:   true,
+		OperationStatusOk:        true,
+		OperationStatusCompleted: true,
+		OperationStatusFailed:    false,
+		OperationStatusFailure:   false,
+	}
+}

--- a/asserter/search.go
+++ b/asserter/search.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asserter/search_test.go
+++ b/asserter/search_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asserter/server.go
+++ b/asserter/server.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asserter/server_test.go
+++ b/asserter/server_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asserter/utils.go
+++ b/asserter/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/client/api_account.go
+++ b/client/api_account.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/client/api_block.go
+++ b/client/api_block.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/client/api_call.go
+++ b/client/api_call.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/client/api_construction.go
+++ b/client/api_construction.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/client/api_events.go
+++ b/client/api_events.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/client/api_mempool.go
+++ b/client/api_mempool.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/client/api_network.go
+++ b/client/api_network.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/client/api_search.go
+++ b/client/api_search.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/client/client.go
+++ b/client/client.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/client/configuration.go
+++ b/client/configuration.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/client/response.go
+++ b/client/response.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/constructor/coordinator/coordinator.go
+++ b/constructor/coordinator/coordinator.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/constructor/coordinator/coordinator_test.go
+++ b/constructor/coordinator/coordinator_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/constructor/coordinator/errors.go
+++ b/constructor/coordinator/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/constructor/coordinator/types.go
+++ b/constructor/coordinator/types.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/constructor/dsl/dsl.go
+++ b/constructor/dsl/dsl.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/constructor/dsl/dsl_test.go
+++ b/constructor/dsl/dsl_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/constructor/dsl/errors.go
+++ b/constructor/dsl/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/constructor/dsl/parser.go
+++ b/constructor/dsl/parser.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/constructor/job/errors.go
+++ b/constructor/job/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/constructor/job/job.go
+++ b/constructor/job/job.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/constructor/job/types.go
+++ b/constructor/job/types.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/constructor/job/utils.go
+++ b/constructor/job/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/constructor/worker/errors.go
+++ b/constructor/worker/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/constructor/worker/populator.go
+++ b/constructor/worker/populator.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/constructor/worker/populator_test.go
+++ b/constructor/worker/populator_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/constructor/worker/types.go
+++ b/constructor/worker/types.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/constructor/worker/worker.go
+++ b/constructor/worker/worker.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/constructor/worker/worker_test.go
+++ b/constructor/worker/worker_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/errors/utils.go
+++ b/errors/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/errors/utils_test.go
+++ b/errors/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/client/main.go
+++ b/examples/client/main.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/fetcher/main.go
+++ b/examples/fetcher/main.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/server/main.go
+++ b/examples/server/main.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/server/services/block_service.go
+++ b/examples/server/services/block_service.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/server/services/network_service.go
+++ b/examples/server/services/network_service.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/fetcher/account.go
+++ b/fetcher/account.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/fetcher/account_test.go
+++ b/fetcher/account_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/fetcher/block.go
+++ b/fetcher/block.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/fetcher/block_test.go
+++ b/fetcher/block_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/fetcher/call.go
+++ b/fetcher/call.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/fetcher/call_test.go
+++ b/fetcher/call_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/fetcher/configuration.go
+++ b/fetcher/configuration.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/fetcher/construction.go
+++ b/fetcher/construction.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/fetcher/errors.go
+++ b/fetcher/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/fetcher/errors_test.go
+++ b/fetcher/errors_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/fetcher/events.go
+++ b/fetcher/events.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/fetcher/events_test.go
+++ b/fetcher/events_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/fetcher/fetcher_test.go
+++ b/fetcher/fetcher_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/fetcher/mempool.go
+++ b/fetcher/mempool.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/fetcher/network.go
+++ b/fetcher/network.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/fetcher/network_test.go
+++ b/fetcher/network_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/fetcher/search.go
+++ b/fetcher/search.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/fetcher/search_test.go
+++ b/fetcher/search_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/fetcher/utils.go
+++ b/fetcher/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/imports.sh
+++ b/imports.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2020 Coinbase, Inc.
+# Copyright 2024 Coinbase, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/keys/errors.go
+++ b/keys/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/keys/errors_test.go
+++ b/keys/errors_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/keys/signer.go
+++ b/keys/signer.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/keys/signer_edwards25519.go
+++ b/keys/signer_edwards25519.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/keys/signer_edwards25519_test.go
+++ b/keys/signer_edwards25519_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/keys/signer_secp256k1.go
+++ b/keys/signer_secp256k1.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/keys/signer_secp256k1_test.go
+++ b/keys/signer_secp256k1_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/keys/signer_secp256r1.go
+++ b/keys/signer_secp256r1.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/keys/signer_secp256r1_test.go
+++ b/keys/signer_secp256r1_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/keys/types.go
+++ b/keys/types.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parser/balance_changes.go
+++ b/parser/balance_changes.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parser/balance_changes_test.go
+++ b/parser/balance_changes_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parser/errors_test.go
+++ b/parser/errors_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parser/exemptions.go
+++ b/parser/exemptions.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parser/exemptions_test.go
+++ b/parser/exemptions_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parser/group_operations.go
+++ b/parser/group_operations.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parser/group_operations_test.go
+++ b/parser/group_operations_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parser/intent.go
+++ b/parser/intent.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parser/intent_test.go
+++ b/parser/intent_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/reconciler/configuration.go
+++ b/reconciler/configuration.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/reconciler/errors.go
+++ b/reconciler/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/reconciler/errors_test.go
+++ b/reconciler/errors_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/reconciler/types.go
+++ b/reconciler/types.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/api.go
+++ b/server/api.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/api_account.go
+++ b/server/api_account.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/api_block.go
+++ b/server/api_block.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/api_call.go
+++ b/server/api_call.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/api_construction.go
+++ b/server/api_construction.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/api_events.go
+++ b/server/api_events.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/api_mempool.go
+++ b/server/api_mempool.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/api_network.go
+++ b/server/api_network.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/api_search.go
+++ b/server/api_search.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/logger.go
+++ b/server/logger.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/routers.go
+++ b/server/routers.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/statefulsyncer/configuration.go
+++ b/statefulsyncer/configuration.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/statefulsyncer/stateful_syncer.go
+++ b/statefulsyncer/stateful_syncer.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/database/badger_database.go
+++ b/storage/database/badger_database.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/database/badger_database_configuration.go
+++ b/storage/database/badger_database_configuration.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/database/badger_database_test.go
+++ b/storage/database/badger_database_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/database/database.go
+++ b/storage/database/database.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/encoder/buffer_pool.go
+++ b/storage/encoder/buffer_pool.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/encoder/encoder.go
+++ b/storage/encoder/encoder.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/encoder/encoder_test.go
+++ b/storage/encoder/encoder_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/errors/errors.go
+++ b/storage/errors/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/errors/errors_test.go
+++ b/storage/errors/errors_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/modules/balance_storage.go
+++ b/storage/modules/balance_storage.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/modules/balance_storage_test.go
+++ b/storage/modules/balance_storage_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/modules/block_storage.go
+++ b/storage/modules/block_storage.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/modules/block_storage_test.go
+++ b/storage/modules/block_storage_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/modules/broadcast_storage.go
+++ b/storage/modules/broadcast_storage.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/modules/broadcast_storage_test.go
+++ b/storage/modules/broadcast_storage_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/modules/coin_storage.go
+++ b/storage/modules/coin_storage.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/modules/coin_storage_test.go
+++ b/storage/modules/coin_storage_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/modules/counter_storage.go
+++ b/storage/modules/counter_storage.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/modules/counter_storage_test.go
+++ b/storage/modules/counter_storage_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/modules/job_storage.go
+++ b/storage/modules/job_storage.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/modules/job_storage_test.go
+++ b/storage/modules/job_storage_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/modules/key_storage.go
+++ b/storage/modules/key_storage.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/modules/key_storage_test.go
+++ b/storage/modules/key_storage_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/modules/utils.go
+++ b/storage/modules/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/syncer/configuration.go
+++ b/syncer/configuration.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/syncer/errors.go
+++ b/syncer/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/syncer/errors_test.go
+++ b/syncer/errors_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/syncer/types.go
+++ b/syncer/types.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/templates/construction_derive_response.txt
+++ b/templates/construction_derive_response.txt
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/templates/construction_parse_response.txt
+++ b/templates/construction_parse_response.txt
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/templates/signing_payload.txt
+++ b/templates/signing_payload.txt
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/account_balance_request.go
+++ b/types/account_balance_request.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/account_balance_response.go
+++ b/types/account_balance_response.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/account_coin.go
+++ b/types/account_coin.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/account_coins_request.go
+++ b/types/account_coins_request.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/account_coins_response.go
+++ b/types/account_coins_response.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/account_currency.go
+++ b/types/account_currency.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/account_identifier.go
+++ b/types/account_identifier.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/allow.go
+++ b/types/allow.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/amount.go
+++ b/types/amount.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/balance_exemption.go
+++ b/types/balance_exemption.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/block.go
+++ b/types/block.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/block_event.go
+++ b/types/block_event.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/block_event_type.go
+++ b/types/block_event_type.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/block_identifier.go
+++ b/types/block_identifier.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/block_request.go
+++ b/types/block_request.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/block_response.go
+++ b/types/block_response.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/block_transaction.go
+++ b/types/block_transaction.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/block_transaction_request.go
+++ b/types/block_transaction_request.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/block_transaction_response.go
+++ b/types/block_transaction_response.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/call_request.go
+++ b/types/call_request.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/call_response.go
+++ b/types/call_response.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/case.go
+++ b/types/case.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/coin.go
+++ b/types/coin.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/coin_action.go
+++ b/types/coin_action.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/coin_change.go
+++ b/types/coin_change.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/coin_identifier.go
+++ b/types/coin_identifier.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/construction_combine_request.go
+++ b/types/construction_combine_request.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/construction_combine_response.go
+++ b/types/construction_combine_response.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/construction_derive_request.go
+++ b/types/construction_derive_request.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/construction_derive_response.go
+++ b/types/construction_derive_response.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/construction_hash_request.go
+++ b/types/construction_hash_request.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/construction_metadata_request.go
+++ b/types/construction_metadata_request.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/construction_metadata_response.go
+++ b/types/construction_metadata_response.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/construction_parse_request.go
+++ b/types/construction_parse_request.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/construction_parse_response.go
+++ b/types/construction_parse_response.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/construction_payloads_request.go
+++ b/types/construction_payloads_request.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/construction_payloads_response.go
+++ b/types/construction_payloads_response.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/construction_preprocess_request.go
+++ b/types/construction_preprocess_request.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/construction_preprocess_response.go
+++ b/types/construction_preprocess_response.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/construction_submit_request.go
+++ b/types/construction_submit_request.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/currency.go
+++ b/types/currency.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/curve_type.go
+++ b/types/curve_type.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/direction.go
+++ b/types/direction.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/error.go
+++ b/types/error.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/events_blocks_request.go
+++ b/types/events_blocks_request.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/events_blocks_response.go
+++ b/types/events_blocks_response.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/exemption_type.go
+++ b/types/exemption_type.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/marshal_test.go
+++ b/types/marshal_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/mempool_response.go
+++ b/types/mempool_response.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/mempool_transaction_request.go
+++ b/types/mempool_transaction_request.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/mempool_transaction_response.go
+++ b/types/mempool_transaction_response.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/metadata_request.go
+++ b/types/metadata_request.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/network_identifier.go
+++ b/types/network_identifier.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/network_list_response.go
+++ b/types/network_list_response.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/network_options_response.go
+++ b/types/network_options_response.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/network_request.go
+++ b/types/network_request.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/network_status_response.go
+++ b/types/network_status_response.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/operation.go
+++ b/types/operation.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/operation_identifier.go
+++ b/types/operation_identifier.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/operation_status.go
+++ b/types/operation_status.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/operator.go
+++ b/types/operator.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/partial_block_identifier.go
+++ b/types/partial_block_identifier.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/peer.go
+++ b/types/peer.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/public_key.go
+++ b/types/public_key.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/related_transaction.go
+++ b/types/related_transaction.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/search_transactions_request.go
+++ b/types/search_transactions_request.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/search_transactions_response.go
+++ b/types/search_transactions_response.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/signature.go
+++ b/types/signature.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/signature_type.go
+++ b/types/signature_type.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/signing_payload.go
+++ b/types/signing_payload.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/sub_account_identifier.go
+++ b/types/sub_account_identifier.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/sub_network_identifier.go
+++ b/types/sub_network_identifier.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/sync_status.go
+++ b/types/sync_status.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/transaction_identifier.go
+++ b/types/transaction_identifier.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/transaction_identifier_response.go
+++ b/types/transaction_identifier_response.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/types.go
+++ b/types/types.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/utils.go
+++ b/types/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/utils_test.go
+++ b/types/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/version.go
+++ b/types/version.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/utils/bst.go
+++ b/utils/bst.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/utils/bst_test.go
+++ b/utils/bst_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/utils/mutex_map.go
+++ b/utils/mutex_map.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/utils/mutex_map_test.go
+++ b/utils/mutex_map_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/utils/priority_mutex.go
+++ b/utils/priority_mutex.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/utils/priority_mutex_test.go
+++ b/utils/priority_mutex_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/utils/sharded_map.go
+++ b/utils/sharded_map.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/utils/sharded_map_test.go
+++ b/utils/sharded_map_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/utils/size.go
+++ b/utils/size.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/utils/size_test.go
+++ b/utils/size_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2024 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes # .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

in somecases, rosetta spec validation is not helpful, and it causes some operation work, so now we add a new client which can ignore rosetta spec validation. 

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
