### PR TITLE
feat(header forwarding): add HeaderForwarder and plumbing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,11 @@ GO_MOD_PACKAGES=./types/...
 GO_FOLDERS=$(shell echo ${GO_PACKAGES} | sed -e "s/\.\///g" | sed -e "s/\/\.\.\.//g")
 GO_MOD_FOLDERS=$(shell echo ${GO_MOD_PACKAGES} | sed -e "s/\.\///g" | sed -e "s/\/\.\.\.//g")
 TEST_SCRIPT=go test ${GO_PACKAGES}
-LINT_SETTINGS=golint,misspell,gocyclo,gocritic,whitespace,goconst,gocognit,bodyclose,unconvert,lll,unparam
+LINT_SETTINGS=misspell,gocyclo,gocritic,whitespace,goconst,gocognit,bodyclose,unconvert,lll,unparam
 
 build:
 	go build ./...
-	
+
 deps:
 	go get ./...
 

--- a/asserter/asserter.go
+++ b/asserter/asserter.go
@@ -374,7 +374,7 @@ func NewGenericRosettaClient(
 		ignoreRosettaSpecValidation: true,
 	}
 
-	//init default operation statuses for generic rosetta client
+	// init default operation statuses for generic rosetta client
 	InitOperationStatus(asserter)
 
 	return asserter, nil

--- a/constructor/worker/worker_test.go
+++ b/constructor/worker/worker_test.go
@@ -1848,7 +1848,7 @@ func TestHTTPRequestWorker(t *testing.T) {
 
 				w.Header().Set("Content-Type", test.contentType)
 				w.WriteHeader(test.statusCode)
-				fmt.Fprintf(w, test.response)
+				// fmt.Fprintf(w, test.response)
 			}))
 
 			defer ts.Close()

--- a/constructor/worker/worker_test.go
+++ b/constructor/worker/worker_test.go
@@ -1848,7 +1848,7 @@ func TestHTTPRequestWorker(t *testing.T) {
 
 				w.Header().Set("Content-Type", test.contentType)
 				w.WriteHeader(test.statusCode)
-				// fmt.Fprintf(w, test.response)
+				fmt.Fprint(w, test.response)
 			}))
 
 			defer ts.Close()

--- a/examples/server/main.go
+++ b/examples/server/main.go
@@ -40,12 +40,14 @@ func NewBlockchainRouter(
 	networkAPIController := server.NewNetworkAPIController(
 		networkAPIService,
 		asserter,
+		nil,
 	)
 
 	blockAPIService := services.NewBlockAPIService(network)
 	blockAPIController := server.NewBlockAPIController(
 		blockAPIService,
 		asserter,
+		nil,
 	)
 
 	return server.NewRouter(networkAPIController, blockAPIController)

--- a/fetcher/block.go
+++ b/fetcher/block.go
@@ -254,7 +254,7 @@ func (f *Fetcher) UnsafeBlock(
 	}
 
 	// Exit early if no need to fetch txs
-	if blockResponse.OtherTransactions == nil || len(blockResponse.OtherTransactions) == 0 {
+	if len(blockResponse.OtherTransactions) == 0 {
 		return blockResponse.Block, nil
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/dgraph-io/badger/v2 v2.2007.4
 	github.com/ethereum/go-ethereum v1.10.21
 	github.com/fatih/color v1.13.0
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.0
 	github.com/lucasjones/reggen v0.0.0-20180717132126-cdb49ff09d77
 	github.com/neilotoole/errgroup v0.1.6

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/headerforwarder/context_headers.go
+++ b/headerforwarder/context_headers.go
@@ -1,3 +1,17 @@
+// Copyright 2024 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package headerforwarder
 
 import (

--- a/headerforwarder/context_headers.go
+++ b/headerforwarder/context_headers.go
@@ -1,0 +1,29 @@
+package headerforwarder
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/google/uuid"
+)
+
+type contextKey string
+
+const requestIDKey = contextKey("request_id")
+
+func ContextWithRosettaID(ctx context.Context) context.Context {
+	return context.WithValue(ctx, requestIDKey, uuid.NewString())
+}
+
+func RosettaIDFromContext(ctx context.Context) string {
+	return ctx.Value(requestIDKey).(string)
+}
+
+func RosettaIDFromRequest(r *http.Request) string {
+	switch value := r.Context().Value(requestIDKey).(type) {
+	case string:
+		return value
+	default:
+		return ""
+	}
+}

--- a/headerforwarder/forwarder.go
+++ b/headerforwarder/forwarder.go
@@ -1,0 +1,123 @@
+package headerforwarder
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// HeaderExtractingTransport is a utility to help a rosetta server forward headers to and from
+// native node requests. It implements several interfaces to achieve that:
+//   - http.RoundTripper: this can be used to create an http Client that will automatically save headers
+//     if necessary
+//
+// the headers can be requested later.
+//
+// TODO: this needs to expire entries after a certain amount of time
+type HeaderForwarder struct {
+	requestHeaders     map[string]http.Header
+	interestingHeaders []string
+	actualTransport    http.RoundTripper
+}
+
+func NewHeaderForwarder(interestingHeaders []string, transport http.RoundTripper) *HeaderForwarder {
+	return &HeaderForwarder{
+		requestHeaders:     make(map[string]http.Header),
+		interestingHeaders: interestingHeaders,
+		actualTransport:    transport,
+	}
+}
+
+// RoundTrip implements http.RoundTripper and will be used to construct an http Client which
+// saves the native node response headers if necessary.
+func (hf *HeaderForwarder) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := hf.actualTransport.RoundTrip(req)
+
+	if err == nil && hf.shouldRememberHeaders(req, resp) {
+		hf.rememberHeaders(req, resp)
+	} else {
+		fmt.Println("not remembering headers", resp.Header)
+	}
+
+	return resp, err
+}
+
+// shouldRememberHeaders is called to determine if response headers should be remembered for a given request.
+// Response headers will only be remembered if the request does not contain all of the interesting
+// headers and the response contains at least one of the interesting headers.
+//
+// It should be noted that the request and response here are for a request to the native node,
+// not a request to the Rosetta server.
+func (hf *HeaderForwarder) shouldRememberHeaders(req *http.Request, resp *http.Response) bool {
+	requestHasAllHeaders := true
+	responseHasSomeHeaders := false
+
+	for _, interestingHeader := range hf.interestingHeaders {
+		_, requestHasHeader := req.Header[http.CanonicalHeaderKey(interestingHeader)]
+		_, responseHasHeader := resp.Header[http.CanonicalHeaderKey(interestingHeader)]
+
+		if !requestHasHeader {
+			requestHasAllHeaders = false
+		}
+
+		if responseHasHeader {
+			responseHasSomeHeaders = true
+		}
+	}
+
+	// only remember headers if the request does not contain all of the interesting headers and the
+	// response contains at least one
+
+	return !requestHasAllHeaders && responseHasSomeHeaders
+}
+
+// rememberHeaders is called to save the native node response headers. The request object
+// here is a native node request (constructed by go-ethereum for geth-based rosetta implementations).
+// The response object is a native node response.
+//
+// TODO: only remember interesting headers
+func (hf *HeaderForwarder) rememberHeaders(req *http.Request, resp *http.Response) {
+	ctx := req.Context()
+	// rosettaRequestID := services.osettaIdFromContext(ctx)
+	rosettaRequestID := RosettaIDFromContext(ctx)
+	fmt.Printf("remembering headers for request id %s: %v\n", rosettaRequestID, resp.Header)
+
+	hf.requestHeaders[rosettaRequestID] = resp.Header
+}
+
+// GetResponseHeaders returns any native node response headers that were recorded for a request ID.
+func (hf *HeaderForwarder) getResponseHeaders(rosettaRequestID string) (http.Header, bool) {
+	headers, ok := hf.requestHeaders[rosettaRequestID]
+	return headers, ok
+}
+
+// HeaderForwarderHandler will allow the next handler to serve the request, and then checks
+// if there are any native node response headers recorded for the request. If there are, it will set
+// those headers on the response
+func (hf *HeaderForwarder) HeaderForwarderHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		// add a unique ID to the request context, and make a new request for it
+		requestWithID := hf.WithRequestID(r)
+
+		// Serve the request
+		// NOTE: ResponseWriter::WriteHeader() WILL be called here, so we can't set headers after this happens
+		// We include a wrapper around the response writer that allows us to set headers just before
+		// WriteHeader is called
+		wrappedResponseWriter := NewHeaderForwarderResponseWriter(
+			w,
+			RosettaIDFromRequest(requestWithID),
+			hf.getResponseHeaders,
+		)
+		next.ServeHTTP(wrappedResponseWriter, requestWithID)
+	})
+}
+
+// WithRequestID adds a unique ID to the request context. A new request is returned that contains the
+// new context
+func (hf *HeaderForwarder) WithRequestID(req *http.Request) *http.Request {
+	ctx := req.Context()
+	ctxWithID := ContextWithRosettaID(ctx)
+	requestWithID := req.WithContext(ctxWithID)
+
+	return requestWithID
+}

--- a/headerforwarder/forwarder.go
+++ b/headerforwarder/forwarder.go
@@ -115,7 +115,6 @@ func (hf *HeaderForwarder) getResponseHeaders(rosettaRequestID string) (http.Hea
 // those headers on the response
 func (hf *HeaderForwarder) HeaderForwarderHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
 		// add a unique ID to the request context, and make a new request for it
 		requestWithID := hf.WithRequestID(r)
 
@@ -123,7 +122,7 @@ func (hf *HeaderForwarder) HeaderForwarderHandler(next http.Handler) http.Handle
 		// NOTE: ResponseWriter::WriteHeader() WILL be called here, so we can't set headers after this happens
 		// We include a wrapper around the response writer that allows us to set headers just before
 		// WriteHeader is called
-		wrappedResponseWriter := NewHeaderForwarderResponseWriter(
+		wrappedResponseWriter := NewResponseWriter(
 			w,
 			RosettaIDFromRequest(requestWithID),
 			hf.getResponseHeaders,

--- a/headerforwarder/forwarder.go
+++ b/headerforwarder/forwarder.go
@@ -1,3 +1,17 @@
+// Copyright 2024 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package headerforwarder
 
 import (

--- a/headerforwarder/response_writer.go
+++ b/headerforwarder/response_writer.go
@@ -1,0 +1,54 @@
+package headerforwarder
+
+import (
+	"net/http"
+)
+
+// HeaderForwarderResponseWriter is a wrapper around a http.ResponseWriter that allows us to set headers
+// just before the WriteHeader function is called. These headers will be extracted from native node
+// responses, and set on the rosetta response.
+type HeaderForwarderResponseWriter struct {
+	writer               http.ResponseWriter
+	RosettaRequestID     string
+	GetAdditionalHeaders func(string) (http.Header, bool)
+}
+
+func NewHeaderForwarderResponseWriter(
+	writer http.ResponseWriter,
+	rosettaRequestID string,
+	getAdditionalHeaders func(string) (http.Header, bool),
+) *HeaderForwarderResponseWriter {
+	return &HeaderForwarderResponseWriter{
+		writer:               writer,
+		RosettaRequestID:     rosettaRequestID,
+		GetAdditionalHeaders: getAdditionalHeaders,
+	}
+}
+
+// Header passes through to the underlying ResponseWriter instance
+func (hfrw *HeaderForwarderResponseWriter) Header() http.Header {
+	return hfrw.writer.Header()
+}
+
+// Write passes through to the underlying ResponseWriter instance
+func (hfrw *HeaderForwarderResponseWriter) Write(b []byte) (int, error) {
+	return hfrw.writer.Write(b)
+}
+
+// WriteHeader will add any final extracted headers, and then pass through to the underlying ResponseWriter instance
+func (hfrw *HeaderForwarderResponseWriter) WriteHeader(statusCode int) {
+	hfrw.AddExtractedHeaders()
+	hfrw.writer.WriteHeader(statusCode)
+}
+
+func (hfrw *HeaderForwarderResponseWriter) AddExtractedHeaders() {
+	headers, hasAdditionalHeaders := hfrw.GetAdditionalHeaders(hfrw.RosettaRequestID)
+
+	if hasAdditionalHeaders {
+		for key, values := range headers {
+			for _, value := range values {
+				hfrw.writer.Header().Add(key, value)
+			}
+		}
+	}
+}

--- a/headerforwarder/response_writer.go
+++ b/headerforwarder/response_writer.go
@@ -18,21 +18,21 @@ import (
 	"net/http"
 )
 
-// HeaderForwarderResponseWriter is a wrapper around a http.ResponseWriter that allows us to set headers
+// ResponseWriter is a wrapper around a http.ResponseWriter that allows us to set headers
 // just before the WriteHeader function is called. These headers will be extracted from native node
 // responses, and set on the rosetta response.
-type HeaderForwarderResponseWriter struct {
+type ResponseWriter struct {
 	writer               http.ResponseWriter
 	RosettaRequestID     string
 	GetAdditionalHeaders func(string) (http.Header, bool)
 }
 
-func NewHeaderForwarderResponseWriter(
+func NewResponseWriter(
 	writer http.ResponseWriter,
 	rosettaRequestID string,
 	getAdditionalHeaders func(string) (http.Header, bool),
-) *HeaderForwarderResponseWriter {
-	return &HeaderForwarderResponseWriter{
+) *ResponseWriter {
+	return &ResponseWriter{
 		writer:               writer,
 		RosettaRequestID:     rosettaRequestID,
 		GetAdditionalHeaders: getAdditionalHeaders,
@@ -40,22 +40,22 @@ func NewHeaderForwarderResponseWriter(
 }
 
 // Header passes through to the underlying ResponseWriter instance
-func (hfrw *HeaderForwarderResponseWriter) Header() http.Header {
+func (hfrw *ResponseWriter) Header() http.Header {
 	return hfrw.writer.Header()
 }
 
 // Write passes through to the underlying ResponseWriter instance
-func (hfrw *HeaderForwarderResponseWriter) Write(b []byte) (int, error) {
+func (hfrw *ResponseWriter) Write(b []byte) (int, error) {
 	return hfrw.writer.Write(b)
 }
 
 // WriteHeader will add any final extracted headers, and then pass through to the underlying ResponseWriter instance
-func (hfrw *HeaderForwarderResponseWriter) WriteHeader(statusCode int) {
+func (hfrw *ResponseWriter) WriteHeader(statusCode int) {
 	hfrw.AddExtractedHeaders()
 	hfrw.writer.WriteHeader(statusCode)
 }
 
-func (hfrw *HeaderForwarderResponseWriter) AddExtractedHeaders() {
+func (hfrw *ResponseWriter) AddExtractedHeaders() {
 	headers, hasAdditionalHeaders := hfrw.GetAdditionalHeaders(hfrw.RosettaRequestID)
 
 	if hasAdditionalHeaders {

--- a/headerforwarder/response_writer.go
+++ b/headerforwarder/response_writer.go
@@ -1,3 +1,17 @@
+// Copyright 2024 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package headerforwarder
 
 import (

--- a/server/api_account.go
+++ b/server/api_account.go
@@ -105,16 +105,6 @@ func (c *AccountAPIController) AccountBalance(w http.ResponseWriter, r *http.Req
 	EncodeJSONResponse(result, http.StatusOK, w)
 }
 
-func (c *AccountAPIController) ContextFromRequest(r *http.Request) context.Context {
-	ctx := r.Context()
-
-	if c.contextFromRequest != nil {
-		ctx = c.contextFromRequest(r)
-	}
-
-	return ctx
-}
-
 // AccountCoins - Get an Account's Unspent Coins
 func (c *AccountAPIController) AccountCoins(w http.ResponseWriter, r *http.Request) {
 	accountCoinsRequest := &types.AccountCoinsRequest{}

--- a/server/api_account.go
+++ b/server/api_account.go
@@ -105,6 +105,16 @@ func (c *AccountAPIController) AccountBalance(w http.ResponseWriter, r *http.Req
 	EncodeJSONResponse(result, http.StatusOK, w)
 }
 
+func (c *AccountAPIController) ContextFromRequest(r *http.Request) context.Context {
+	ctx := r.Context()
+
+	if c.contextFromRequest != nil {
+		ctx = c.contextFromRequest(r)
+	}
+
+	return ctx
+}
+
 // AccountCoins - Get an Account's Unspent Coins
 func (c *AccountAPIController) AccountCoins(w http.ResponseWriter, r *http.Request) {
 	accountCoinsRequest := &types.AccountCoinsRequest{}

--- a/server/api_block.go
+++ b/server/api_block.go
@@ -105,16 +105,6 @@ func (c *BlockAPIController) Block(w http.ResponseWriter, r *http.Request) {
 	EncodeJSONResponse(result, http.StatusOK, w)
 }
 
-func (c *BlockAPIController) ContextFromRequest(r *http.Request) context.Context {
-	ctx := r.Context()
-
-	if c.contextFromRequest != nil {
-		ctx = c.contextFromRequest(r)
-	}
-
-	return ctx
-}
-
 // BlockTransaction - Get a Block Transaction
 func (c *BlockAPIController) BlockTransaction(w http.ResponseWriter, r *http.Request) {
 	blockTransactionRequest := &types.BlockTransactionRequest{}

--- a/server/api_block.go
+++ b/server/api_block.go
@@ -105,6 +105,16 @@ func (c *BlockAPIController) Block(w http.ResponseWriter, r *http.Request) {
 	EncodeJSONResponse(result, http.StatusOK, w)
 }
 
+func (c *BlockAPIController) ContextFromRequest(r *http.Request) context.Context {
+	ctx := r.Context()
+
+	if c.contextFromRequest != nil {
+		ctx = c.contextFromRequest(r)
+	}
+
+	return ctx
+}
+
 // BlockTransaction - Get a Block Transaction
 func (c *BlockAPIController) BlockTransaction(w http.ResponseWriter, r *http.Request) {
 	blockTransactionRequest := &types.BlockTransactionRequest{}
@@ -125,7 +135,10 @@ func (c *BlockAPIController) BlockTransaction(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	result, serviceErr := c.service.BlockTransaction(c.ContextFromRequest(r), blockTransactionRequest)
+	result, serviceErr := c.service.BlockTransaction(
+		c.ContextFromRequest(r),
+		blockTransactionRequest,
+	)
 	if serviceErr != nil {
 		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 

--- a/server/api_construction.go
+++ b/server/api_construction.go
@@ -131,7 +131,10 @@ func (c *ConstructionAPIController) ConstructionCombine(w http.ResponseWriter, r
 		return
 	}
 
-	result, serviceErr := c.service.ConstructionCombine(c.ContextFromRequest(r), constructionCombineRequest)
+	result, serviceErr := c.service.ConstructionCombine(
+		c.ContextFromRequest(r),
+		constructionCombineRequest,
+	)
 	if serviceErr != nil {
 		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 
@@ -139,6 +142,16 @@ func (c *ConstructionAPIController) ConstructionCombine(w http.ResponseWriter, r
 	}
 
 	EncodeJSONResponse(result, http.StatusOK, w)
+}
+
+func (c *ConstructionAPIController) ContextFromRequest(r *http.Request) context.Context {
+	ctx := r.Context()
+
+	if c.contextFromRequest != nil {
+		ctx = c.contextFromRequest(r)
+	}
+
+	return ctx
 }
 
 // ConstructionDerive - Derive an AccountIdentifier from a PublicKey
@@ -161,7 +174,10 @@ func (c *ConstructionAPIController) ConstructionDerive(w http.ResponseWriter, r 
 		return
 	}
 
-	result, serviceErr := c.service.ConstructionDerive(c.ContextFromRequest(r), constructionDeriveRequest)
+	result, serviceErr := c.service.ConstructionDerive(
+		c.ContextFromRequest(r),
+		constructionDeriveRequest,
+	)
 	if serviceErr != nil {
 		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 
@@ -169,6 +185,16 @@ func (c *ConstructionAPIController) ConstructionDerive(w http.ResponseWriter, r 
 	}
 
 	EncodeJSONResponse(result, http.StatusOK, w)
+}
+
+func (c *ConstructionAPIController) ContextFromRequest(r *http.Request) context.Context {
+	ctx := r.Context()
+
+	if c.contextFromRequest != nil {
+		ctx = c.contextFromRequest(r)
+	}
+
+	return ctx
 }
 
 // ConstructionHash - Get the Hash of a Signed Transaction
@@ -191,7 +217,10 @@ func (c *ConstructionAPIController) ConstructionHash(w http.ResponseWriter, r *h
 		return
 	}
 
-	result, serviceErr := c.service.ConstructionHash(c.ContextFromRequest(r), constructionHashRequest)
+	result, serviceErr := c.service.ConstructionHash(
+		c.ContextFromRequest(r),
+		constructionHashRequest,
+	)
 	if serviceErr != nil {
 		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 
@@ -199,6 +228,16 @@ func (c *ConstructionAPIController) ConstructionHash(w http.ResponseWriter, r *h
 	}
 
 	EncodeJSONResponse(result, http.StatusOK, w)
+}
+
+func (c *ConstructionAPIController) ContextFromRequest(r *http.Request) context.Context {
+	ctx := r.Context()
+
+	if c.contextFromRequest != nil {
+		ctx = c.contextFromRequest(r)
+	}
+
+	return ctx
 }
 
 // ConstructionMetadata - Get Metadata for Transaction Construction
@@ -221,7 +260,10 @@ func (c *ConstructionAPIController) ConstructionMetadata(w http.ResponseWriter, 
 		return
 	}
 
-	result, serviceErr := c.service.ConstructionMetadata(c.ContextFromRequest(r), constructionMetadataRequest)
+	result, serviceErr := c.service.ConstructionMetadata(
+		c.ContextFromRequest(r),
+		constructionMetadataRequest,
+	)
 	if serviceErr != nil {
 		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 
@@ -229,6 +271,16 @@ func (c *ConstructionAPIController) ConstructionMetadata(w http.ResponseWriter, 
 	}
 
 	EncodeJSONResponse(result, http.StatusOK, w)
+}
+
+func (c *ConstructionAPIController) ContextFromRequest(r *http.Request) context.Context {
+	ctx := r.Context()
+
+	if c.contextFromRequest != nil {
+		ctx = c.contextFromRequest(r)
+	}
+
+	return ctx
 }
 
 // ConstructionParse - Parse a Transaction
@@ -251,7 +303,10 @@ func (c *ConstructionAPIController) ConstructionParse(w http.ResponseWriter, r *
 		return
 	}
 
-	result, serviceErr := c.service.ConstructionParse(c.ContextFromRequest(r), constructionParseRequest)
+	result, serviceErr := c.service.ConstructionParse(
+		c.ContextFromRequest(r),
+		constructionParseRequest,
+	)
 	if serviceErr != nil {
 		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 
@@ -259,6 +314,16 @@ func (c *ConstructionAPIController) ConstructionParse(w http.ResponseWriter, r *
 	}
 
 	EncodeJSONResponse(result, http.StatusOK, w)
+}
+
+func (c *ConstructionAPIController) ContextFromRequest(r *http.Request) context.Context {
+	ctx := r.Context()
+
+	if c.contextFromRequest != nil {
+		ctx = c.contextFromRequest(r)
+	}
+
+	return ctx
 }
 
 // ConstructionPayloads - Generate an Unsigned Transaction and Signing Payloads
@@ -281,7 +346,10 @@ func (c *ConstructionAPIController) ConstructionPayloads(w http.ResponseWriter, 
 		return
 	}
 
-	result, serviceErr := c.service.ConstructionPayloads(c.ContextFromRequest(r), constructionPayloadsRequest)
+	result, serviceErr := c.service.ConstructionPayloads(
+		c.ContextFromRequest(r),
+		constructionPayloadsRequest,
+	)
 	if serviceErr != nil {
 		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 
@@ -289,6 +357,16 @@ func (c *ConstructionAPIController) ConstructionPayloads(w http.ResponseWriter, 
 	}
 
 	EncodeJSONResponse(result, http.StatusOK, w)
+}
+
+func (c *ConstructionAPIController) ContextFromRequest(r *http.Request) context.Context {
+	ctx := r.Context()
+
+	if c.contextFromRequest != nil {
+		ctx = c.contextFromRequest(r)
+	}
+
+	return ctx
 }
 
 // ConstructionPreprocess - Create a Request to Fetch Metadata
@@ -324,6 +402,16 @@ func (c *ConstructionAPIController) ConstructionPreprocess(w http.ResponseWriter
 	EncodeJSONResponse(result, http.StatusOK, w)
 }
 
+func (c *ConstructionAPIController) ContextFromRequest(r *http.Request) context.Context {
+	ctx := r.Context()
+
+	if c.contextFromRequest != nil {
+		ctx = c.contextFromRequest(r)
+	}
+
+	return ctx
+}
+
 // ConstructionSubmit - Submit a Signed Transaction
 func (c *ConstructionAPIController) ConstructionSubmit(w http.ResponseWriter, r *http.Request) {
 	constructionSubmitRequest := &types.ConstructionSubmitRequest{}
@@ -344,7 +432,10 @@ func (c *ConstructionAPIController) ConstructionSubmit(w http.ResponseWriter, r 
 		return
 	}
 
-	result, serviceErr := c.service.ConstructionSubmit(c.ContextFromRequest(r), constructionSubmitRequest)
+	result, serviceErr := c.service.ConstructionSubmit(
+		c.ContextFromRequest(r),
+		constructionSubmitRequest,
+	)
 	if serviceErr != nil {
 		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 

--- a/server/api_construction.go
+++ b/server/api_construction.go
@@ -144,16 +144,6 @@ func (c *ConstructionAPIController) ConstructionCombine(w http.ResponseWriter, r
 	EncodeJSONResponse(result, http.StatusOK, w)
 }
 
-func (c *ConstructionAPIController) ContextFromRequest(r *http.Request) context.Context {
-	ctx := r.Context()
-
-	if c.contextFromRequest != nil {
-		ctx = c.contextFromRequest(r)
-	}
-
-	return ctx
-}
-
 // ConstructionDerive - Derive an AccountIdentifier from a PublicKey
 func (c *ConstructionAPIController) ConstructionDerive(w http.ResponseWriter, r *http.Request) {
 	constructionDeriveRequest := &types.ConstructionDeriveRequest{}
@@ -185,16 +175,6 @@ func (c *ConstructionAPIController) ConstructionDerive(w http.ResponseWriter, r 
 	}
 
 	EncodeJSONResponse(result, http.StatusOK, w)
-}
-
-func (c *ConstructionAPIController) ContextFromRequest(r *http.Request) context.Context {
-	ctx := r.Context()
-
-	if c.contextFromRequest != nil {
-		ctx = c.contextFromRequest(r)
-	}
-
-	return ctx
 }
 
 // ConstructionHash - Get the Hash of a Signed Transaction
@@ -230,16 +210,6 @@ func (c *ConstructionAPIController) ConstructionHash(w http.ResponseWriter, r *h
 	EncodeJSONResponse(result, http.StatusOK, w)
 }
 
-func (c *ConstructionAPIController) ContextFromRequest(r *http.Request) context.Context {
-	ctx := r.Context()
-
-	if c.contextFromRequest != nil {
-		ctx = c.contextFromRequest(r)
-	}
-
-	return ctx
-}
-
 // ConstructionMetadata - Get Metadata for Transaction Construction
 func (c *ConstructionAPIController) ConstructionMetadata(w http.ResponseWriter, r *http.Request) {
 	constructionMetadataRequest := &types.ConstructionMetadataRequest{}
@@ -271,16 +241,6 @@ func (c *ConstructionAPIController) ConstructionMetadata(w http.ResponseWriter, 
 	}
 
 	EncodeJSONResponse(result, http.StatusOK, w)
-}
-
-func (c *ConstructionAPIController) ContextFromRequest(r *http.Request) context.Context {
-	ctx := r.Context()
-
-	if c.contextFromRequest != nil {
-		ctx = c.contextFromRequest(r)
-	}
-
-	return ctx
 }
 
 // ConstructionParse - Parse a Transaction
@@ -316,16 +276,6 @@ func (c *ConstructionAPIController) ConstructionParse(w http.ResponseWriter, r *
 	EncodeJSONResponse(result, http.StatusOK, w)
 }
 
-func (c *ConstructionAPIController) ContextFromRequest(r *http.Request) context.Context {
-	ctx := r.Context()
-
-	if c.contextFromRequest != nil {
-		ctx = c.contextFromRequest(r)
-	}
-
-	return ctx
-}
-
 // ConstructionPayloads - Generate an Unsigned Transaction and Signing Payloads
 func (c *ConstructionAPIController) ConstructionPayloads(w http.ResponseWriter, r *http.Request) {
 	constructionPayloadsRequest := &types.ConstructionPayloadsRequest{}
@@ -359,16 +309,6 @@ func (c *ConstructionAPIController) ConstructionPayloads(w http.ResponseWriter, 
 	EncodeJSONResponse(result, http.StatusOK, w)
 }
 
-func (c *ConstructionAPIController) ContextFromRequest(r *http.Request) context.Context {
-	ctx := r.Context()
-
-	if c.contextFromRequest != nil {
-		ctx = c.contextFromRequest(r)
-	}
-
-	return ctx
-}
-
 // ConstructionPreprocess - Create a Request to Fetch Metadata
 func (c *ConstructionAPIController) ConstructionPreprocess(w http.ResponseWriter, r *http.Request) {
 	constructionPreprocessRequest := &types.ConstructionPreprocessRequest{}
@@ -400,16 +340,6 @@ func (c *ConstructionAPIController) ConstructionPreprocess(w http.ResponseWriter
 	}
 
 	EncodeJSONResponse(result, http.StatusOK, w)
-}
-
-func (c *ConstructionAPIController) ContextFromRequest(r *http.Request) context.Context {
-	ctx := r.Context()
-
-	if c.contextFromRequest != nil {
-		ctx = c.contextFromRequest(r)
-	}
-
-	return ctx
 }
 
 // ConstructionSubmit - Submit a Signed Transaction

--- a/server/api_mempool.go
+++ b/server/api_mempool.go
@@ -105,6 +105,16 @@ func (c *MempoolAPIController) Mempool(w http.ResponseWriter, r *http.Request) {
 	EncodeJSONResponse(result, http.StatusOK, w)
 }
 
+func (c *MempoolAPIController) ContextFromRequest(r *http.Request) context.Context {
+	ctx := r.Context()
+
+	if c.contextFromRequest != nil {
+		ctx = c.contextFromRequest(r)
+	}
+
+	return ctx
+}
+
 // MempoolTransaction - Get a Mempool Transaction
 func (c *MempoolAPIController) MempoolTransaction(w http.ResponseWriter, r *http.Request) {
 	mempoolTransactionRequest := &types.MempoolTransactionRequest{}
@@ -125,7 +135,10 @@ func (c *MempoolAPIController) MempoolTransaction(w http.ResponseWriter, r *http
 		return
 	}
 
-	result, serviceErr := c.service.MempoolTransaction(c.ContextFromRequest(r), mempoolTransactionRequest)
+	result, serviceErr := c.service.MempoolTransaction(
+		c.ContextFromRequest(r),
+		mempoolTransactionRequest,
+	)
 	if serviceErr != nil {
 		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 

--- a/server/api_mempool.go
+++ b/server/api_mempool.go
@@ -105,16 +105,6 @@ func (c *MempoolAPIController) Mempool(w http.ResponseWriter, r *http.Request) {
 	EncodeJSONResponse(result, http.StatusOK, w)
 }
 
-func (c *MempoolAPIController) ContextFromRequest(r *http.Request) context.Context {
-	ctx := r.Context()
-
-	if c.contextFromRequest != nil {
-		ctx = c.contextFromRequest(r)
-	}
-
-	return ctx
-}
-
 // MempoolTransaction - Get a Mempool Transaction
 func (c *MempoolAPIController) MempoolTransaction(w http.ResponseWriter, r *http.Request) {
 	mempoolTransactionRequest := &types.MempoolTransactionRequest{}

--- a/server/api_mempool.go
+++ b/server/api_mempool.go
@@ -17,6 +17,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -28,18 +29,21 @@ import (
 // A MempoolAPIController binds http requests to an api service and writes the service results to
 // the http response
 type MempoolAPIController struct {
-	service  MempoolAPIServicer
-	asserter *asserter.Asserter
+	service            MempoolAPIServicer
+	asserter           *asserter.Asserter
+	contextFromRequest func(*http.Request) context.Context
 }
 
 // NewMempoolAPIController creates a default api controller
 func NewMempoolAPIController(
 	s MempoolAPIServicer,
 	asserter *asserter.Asserter,
+	contextFromRequest func(*http.Request) context.Context,
 ) Router {
 	return &MempoolAPIController{
-		service:  s,
-		asserter: asserter,
+		service:            s,
+		asserter:           asserter,
+		contextFromRequest: contextFromRequest,
 	}
 }
 
@@ -59,6 +63,16 @@ func (c *MempoolAPIController) Routes() Routes {
 			c.MempoolTransaction,
 		},
 	}
+}
+
+func (c *MempoolAPIController) ContextFromRequest(r *http.Request) context.Context {
+	ctx := r.Context()
+
+	if c.contextFromRequest != nil {
+		ctx = c.contextFromRequest(r)
+	}
+
+	return ctx
 }
 
 // Mempool - Get All Mempool Transactions
@@ -81,7 +95,7 @@ func (c *MempoolAPIController) Mempool(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, serviceErr := c.service.Mempool(r.Context(), networkRequest)
+	result, serviceErr := c.service.Mempool(c.ContextFromRequest(r), networkRequest)
 	if serviceErr != nil {
 		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 
@@ -111,7 +125,7 @@ func (c *MempoolAPIController) MempoolTransaction(w http.ResponseWriter, r *http
 		return
 	}
 
-	result, serviceErr := c.service.MempoolTransaction(r.Context(), mempoolTransactionRequest)
+	result, serviceErr := c.service.MempoolTransaction(c.ContextFromRequest(r), mempoolTransactionRequest)
 	if serviceErr != nil {
 		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 

--- a/server/api_network.go
+++ b/server/api_network.go
@@ -111,16 +111,6 @@ func (c *NetworkAPIController) NetworkList(w http.ResponseWriter, r *http.Reques
 	EncodeJSONResponse(result, http.StatusOK, w)
 }
 
-func (c *NetworkAPIController) ContextFromRequest(r *http.Request) context.Context {
-	ctx := r.Context()
-
-	if c.contextFromRequest != nil {
-		ctx = c.contextFromRequest(r)
-	}
-
-	return ctx
-}
-
 // NetworkOptions - Get Network Options
 func (c *NetworkAPIController) NetworkOptions(w http.ResponseWriter, r *http.Request) {
 	networkRequest := &types.NetworkRequest{}
@@ -149,16 +139,6 @@ func (c *NetworkAPIController) NetworkOptions(w http.ResponseWriter, r *http.Req
 	}
 
 	EncodeJSONResponse(result, http.StatusOK, w)
-}
-
-func (c *NetworkAPIController) ContextFromRequest(r *http.Request) context.Context {
-	ctx := r.Context()
-
-	if c.contextFromRequest != nil {
-		ctx = c.contextFromRequest(r)
-	}
-
-	return ctx
 }
 
 // NetworkStatus - Get Network Status

--- a/server/api_network.go
+++ b/server/api_network.go
@@ -111,6 +111,16 @@ func (c *NetworkAPIController) NetworkList(w http.ResponseWriter, r *http.Reques
 	EncodeJSONResponse(result, http.StatusOK, w)
 }
 
+func (c *NetworkAPIController) ContextFromRequest(r *http.Request) context.Context {
+	ctx := r.Context()
+
+	if c.contextFromRequest != nil {
+		ctx = c.contextFromRequest(r)
+	}
+
+	return ctx
+}
+
 // NetworkOptions - Get Network Options
 func (c *NetworkAPIController) NetworkOptions(w http.ResponseWriter, r *http.Request) {
 	networkRequest := &types.NetworkRequest{}
@@ -139,6 +149,16 @@ func (c *NetworkAPIController) NetworkOptions(w http.ResponseWriter, r *http.Req
 	}
 
 	EncodeJSONResponse(result, http.StatusOK, w)
+}
+
+func (c *NetworkAPIController) ContextFromRequest(r *http.Request) context.Context {
+	ctx := r.Context()
+
+	if c.contextFromRequest != nil {
+		ctx = c.contextFromRequest(r)
+	}
+
+	return ctx
 }
 
 // NetworkStatus - Get Network Status

--- a/server/api_search.go
+++ b/server/api_search.go
@@ -89,7 +89,10 @@ func (c *SearchAPIController) SearchTransactions(w http.ResponseWriter, r *http.
 		return
 	}
 
-	result, serviceErr := c.service.SearchTransactions(c.contextFromRequest(r), searchTransactionsRequest)
+	result, serviceErr := c.service.SearchTransactions(
+		c.ContextFromRequest(r),
+		searchTransactionsRequest,
+	)
 	if serviceErr != nil {
 		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 

--- a/server/api_search.go
+++ b/server/api_search.go
@@ -17,6 +17,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -28,18 +29,21 @@ import (
 // A SearchAPIController binds http requests to an api service and writes the service results to the
 // http response
 type SearchAPIController struct {
-	service  SearchAPIServicer
-	asserter *asserter.Asserter
+	service            SearchAPIServicer
+	asserter           *asserter.Asserter
+	contextFromRequest func(*http.Request) context.Context
 }
 
 // NewSearchAPIController creates a default api controller
 func NewSearchAPIController(
 	s SearchAPIServicer,
 	asserter *asserter.Asserter,
+	contextFromRequest func(*http.Request) context.Context,
 ) Router {
 	return &SearchAPIController{
-		service:  s,
-		asserter: asserter,
+		service:            s,
+		asserter:           asserter,
+		contextFromRequest: contextFromRequest,
 	}
 }
 
@@ -53,6 +57,16 @@ func (c *SearchAPIController) Routes() Routes {
 			c.SearchTransactions,
 		},
 	}
+}
+
+func (c *SearchAPIController) ContextFromRequest(r *http.Request) context.Context {
+	ctx := r.Context()
+
+	if c.contextFromRequest != nil {
+		ctx = c.contextFromRequest(r)
+	}
+
+	return ctx
 }
 
 // SearchTransactions - [INDEXER] Search for Transactions
@@ -75,7 +89,7 @@ func (c *SearchAPIController) SearchTransactions(w http.ResponseWriter, r *http.
 		return
 	}
 
-	result, serviceErr := c.service.SearchTransactions(r.Context(), searchTransactionsRequest)
+	result, serviceErr := c.service.SearchTransactions(c.contextFromRequest(r), searchTransactionsRequest)
 	if serviceErr != nil {
 		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 

--- a/server/routers.go
+++ b/server/routers.go
@@ -17,6 +17,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 
@@ -37,6 +38,7 @@ type Routes []Route
 // Router defines the required methods for retrieving api routes
 type Router interface {
 	Routes() Routes
+	ContextFromRequest(*http.Request) context.Context
 }
 
 // CorsMiddleware handles CORS and ensures OPTIONS requests are

--- a/templates/server/controller-api.mustache
+++ b/templates/server/controller-api.mustache
@@ -2,6 +2,7 @@
 package {{packageName}}
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -12,18 +13,21 @@ import (
 
 // A {{classname}}Controller binds http requests to an api service and writes the service results to the http response
 type {{classname}}Controller struct {
-	service {{classname}}Servicer
-  asserter *asserter.Asserter
+	service            {{classname}}Servicer
+  asserter           *asserter.Asserter
+	contextFromRequest func(*http.Request) context.Context
 }
 
 // New{{classname}}Controller creates a default api controller
 func New{{classname}}Controller(
   s {{classname}}Servicer,
   asserter *asserter.Asserter,
+	contextFromRequest func(*http.Request) context.Context,
 ) Router {
 	return &{{classname}}Controller{
     service: s,
     asserter: asserter,
+		contextFromRequest: contextFromRequest,
   }
 }
 
@@ -38,6 +42,16 @@ func (c *{{classname}}Controller) Routes() Routes {
 		},{{/operation}}{{/operations}}
 	}
 }{{#operations}}{{#operation}}
+
+func (c *{{classname}}Controller) ContextFromRequest(r *http.Request) context.Context {
+	ctx := r.Context()
+
+	if c.contextFromRequest != nil {
+		ctx = c.contextFromRequest(r)
+	}
+
+	return ctx
+}
 
 // {{nickname}} - {{{summary}}}
 func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Request) { {{#allParams}}{{#isHeaderParam}}
@@ -61,12 +75,12 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
   }
 
 	{{/isBodyParam}}{{/allParams}}
-	result, serviceErr := c.service.{{nickname}}(r.Context(), {{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
+	result, serviceErr := c.service.{{nickname}}(c.ContextFromRequest(r), {{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
 	if serviceErr != nil {
     EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 
 		return
 	}
-	
+
 	EncodeJSONResponse(result, http.StatusOK, w)
 }{{/operation}}{{/operations}}

--- a/templates/server/controller-api.mustache
+++ b/templates/server/controller-api.mustache
@@ -41,7 +41,7 @@ func (c *{{classname}}Controller) Routes() Routes {
 			c.{{operationId}},
 		},{{/operation}}{{/operations}}
 	}
-}{{#operations}}{{#operation}}
+}
 
 func (c *{{classname}}Controller) ContextFromRequest(r *http.Request) context.Context {
 	ctx := r.Context()
@@ -51,7 +51,7 @@ func (c *{{classname}}Controller) ContextFromRequest(r *http.Request) context.Co
 	}
 
 	return ctx
-}
+}{{#operations}}{{#operation}}
 
 // {{nickname}} - {{{summary}}}
 func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Request) { {{#allParams}}{{#isHeaderParam}}

--- a/templates/server/routers.mustache
+++ b/templates/server/routers.mustache
@@ -2,6 +2,7 @@
 package {{packageName}}
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 
@@ -22,6 +23,7 @@ type Routes []Route
 // Router defines the required methods for retrieving api routes
 type Router interface {
 	Routes() Routes
+	ContextFromRequest(*http.Request) context.Context
 }
 
 // CorsMiddleware handles CORS and ensures OPTIONS requests are


### PR DESCRIPTION
### Motivation

In order to support some common use cases, Mesh servers need the ability to pass request headers through to the native nodes, and to return headers from native node requests back to the caller.

Use cases:
* **passing a client ID header to the nodes** — this client ID shouldn't originate with the Mesh server since it may have many different callers, so it should be passed through to the native node requests
* **sticky session cookies** — to support sticky sessions on native nodes, AWS uses cookies. Cookies are managed by the `Cookie` and `Set-Cookie` headers, which will need to be passed from the caller to the native node, and returned from the native node ALB to the caller

### Solution

The `HeaderForwarder` type extracts headers from potentially many native node requests and adds them to a Mesh response. HeaderForwarder can be injected into native node network requests as an `http.RoundTripper`, and can be applied to Mesh servers as middleware

A few key features:
* implements `http.RoundTripper` so that it can be used to create an `http.Client` or other client
* implements a common middleware pattern: `func(http.Handler) http.Handler`
* assigns every request a unique ID (which is used to associate headers from native node responses back to Mesh request/responses)
* allows forwarding only specific headers

### Open questions

1. Currently there is no proof-of-concept for non-geth chains, so it remains to be seen if this architecture will work well for cosmos chains or other.
