### PR TITLE
Update spec to 1.4.15

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -41,7 +41,7 @@ var (
 	ErrRetriable = errors.New("retriable http status code received")
 )
 
-// APIClient manages communication with the Rosetta API v1.4.12
+// APIClient manages communication with the Rosetta API v1.4.13
 // In most cases there should be only one, shared, APIClient.
 type APIClient struct {
 	cfg    *Configuration

--- a/codegen.sh
+++ b/codegen.sh
@@ -53,7 +53,7 @@ done
 rm -rf tmp;
 
 # Download spec file from releases
-ROSETTA_SPEC_VERSION=1.4.12
+ROSETTA_SPEC_VERSION=1.4.15
 curl -L https://github.com/coinbase/rosetta-specifications/releases/download/v${ROSETTA_SPEC_VERSION}/api.json -o api.json;
 
 # Generate client + types code
@@ -125,6 +125,7 @@ sed "${SED_IFLAG[@]}" 's/*Case/Case/g' client/* server/*;
 
 # Fix CurveTypes, SignatureTypes, CoinActions, ExemptionTypes, Direction, Case
 sed "${SED_IFLAG[@]}" 's/SECP256K1/Secp256k1/g' client/* server/*;
+sed "${SED_IFLAG[@]}" 's/Secp256k1_BIP340/Secp256k1Bip340/g' client/* server/*;
 sed "${SED_IFLAG[@]}" 's/SECP256R1/Secp256r1/g' client/* server/*;
 sed "${SED_IFLAG[@]}" 's/EDWARDS25519/Edwards25519/g' client/* server/*;
 sed "${SED_IFLAG[@]}" 's/TWEEDLE/Tweedle/g' client/* server/*;
@@ -132,6 +133,7 @@ sed "${SED_IFLAG[@]}" 's/ECDSA_RECOVERY/EcdsaRecovery/g' client/* server/*;
 sed "${SED_IFLAG[@]}" 's/ECDSA/Ecdsa/g' client/* server/*;
 sed "${SED_IFLAG[@]}" 's/ED25519/Ed25519/g' client/* server/*;
 sed "${SED_IFLAG[@]}" 's/SCHNORR_1/Schnorr1/g' client/* server/*;
+sed "${SED_IFLAG[@]}" 's/SCHNORR_BIP340/SchnorrBip340/g' client/* server/*;
 sed "${SED_IFLAG[@]}" 's/SCHNORR_POSEIDON/SchnorrPoseidon/g' client/* server/*;
 sed "${SED_IFLAG[@]}" 's/PALLAS/Pallas/g' client/* server/*;
 sed "${SED_IFLAG[@]}" 's/CREATED/CoinCreated/g' client/* server/*;

--- a/types/construction_preprocess_request.go
+++ b/types/construction_preprocess_request.go
@@ -21,18 +21,9 @@ package types
 // it needs to request for construction. Metadata provided in this object should NEVER be a product
 // of live data (i.e. the caller must follow some network-specific data fetching strategy outside of
 // the Construction API to populate required Metadata). If live data is required for construction,
-// it MUST be fetched in the call to `/construction/metadata`. The caller can provide a max fee they
-// are willing to pay for a transaction. This is an array in the case fees must be paid in multiple
-// currencies. The caller can also provide a suggested fee multiplier to indicate that the suggested
-// fee should be scaled. This may be used to set higher fees for urgent transactions or to pay lower
-// fees when there is less urgency. It is assumed that providing a very low multiplier (like 0.0001)
-// will never lead to a transaction being created with a fee less than the minimum network fee (if
-// applicable). In the case that the caller provides both a max fee and a suggested fee multiplier,
-// the max fee will set an upper bound on the suggested fee (regardless of the multiplier provided).
+// it MUST be fetched in the call to `/construction/metadata`.
 type ConstructionPreprocessRequest struct {
-	NetworkIdentifier      *NetworkIdentifier     `json:"network_identifier"`
-	Operations             []*Operation           `json:"operations"`
-	Metadata               map[string]interface{} `json:"metadata,omitempty"`
-	MaxFee                 []*Amount              `json:"max_fee,omitempty"`
-	SuggestedFeeMultiplier *float64               `json:"suggested_fee_multiplier,omitempty"`
+	NetworkIdentifier *NetworkIdentifier     `json:"network_identifier"`
+	Operations        []*Operation           `json:"operations"`
+	Metadata          map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/types/curve_type.go
+++ b/types/curve_type.go
@@ -17,19 +17,24 @@
 package types
 
 // CurveType CurveType is the type of cryptographic curve associated with a PublicKey. * secp256k1:
-// SEC compressed - `33 bytes` (https://secg.org/sec1-v2.pdf#subsubsection.2.3.3) * secp256r1: SEC
-// compressed - `33 bytes` (https://secg.org/sec1-v2.pdf#subsubsection.2.3.3) * edwards25519: `y
-// (255-bits) || x-sign-bit (1-bit)` - `32 bytes` (https://ed25519.cr.yp.to/ed25519-20110926.pdf) *
-// tweedle: 1st pk : Fq.t (32 bytes) || 2nd pk : Fq.t (32 bytes)
+// SEC compressed - `33 bytes` (https://secg.org/sec1-v2.pdf#subsubsection.2.3.3) *
+// secp256k1_bip340: x-only - `32 bytes`  (implicitly even `Y` coord. Secp256k1 compressed keys may
+// be repurposed by dropping the first byte.
+// (https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki#Public_Key_Generation)) *
+// secp256r1: SEC compressed - `33 bytes` (https://secg.org/sec1-v2.pdf#subsubsection.2.3.3) *
+// edwards25519: `y (255-bits) || x-sign-bit (1-bit)` - `32 bytes`
+// (https://ed25519.cr.yp.to/ed25519-20110926.pdf) * tweedle: 1st pk : Fq.t (32 bytes) || 2nd pk :
+// Fq.t (32 bytes)
 // (https://github.com/CodaProtocol/coda/blob/develop/rfcs/0038-rosetta-construction-api.md#marshal-keys)
 // * pallas: `x (255 bits) || y-parity-bit (1-bit) - 32 bytes` (https://github.com/zcash/pasta)
 type CurveType string
 
 // List of CurveType
 const (
-	Secp256k1    CurveType = "secp256k1"
-	Secp256r1    CurveType = "secp256r1"
-	Edwards25519 CurveType = "edwards25519"
-	Tweedle      CurveType = "tweedle"
-	Pallas       CurveType = "pallas"
+	Secp256k1       CurveType = "secp256k1"
+	Secp256k1Bip340 CurveType = "secp256k1_bip340"
+	Secp256r1       CurveType = "secp256r1"
+	Edwards25519    CurveType = "edwards25519"
+	Tweedle         CurveType = "tweedle"
+	Pallas          CurveType = "pallas"
 )

--- a/types/network_status_response.go
+++ b/types/network_status_response.go
@@ -33,5 +33,5 @@ type NetworkStatusResponse struct {
 	GenesisBlockIdentifier *BlockIdentifier `json:"genesis_block_identifier"`
 	OldestBlockIdentifier  *BlockIdentifier `json:"oldest_block_identifier,omitempty"`
 	SyncStatus             *SyncStatus      `json:"sync_status,omitempty"`
-	Peers                  []*Peer          `json:"peers"`
+	Peers                  []*Peer          `json:"peers,omitempty"`
 }

--- a/types/signature_type.go
+++ b/types/signature_type.go
@@ -20,10 +20,12 @@ package types
 // (32-bytes)` - `64 bytes` * ecdsa_recovery: `r (32-bytes) || s (32-bytes) || v (1-byte)` - `65
 // bytes` * ed25519: `R (32-byte) || s (32-bytes)` - `64 bytes` * schnorr_1: `r (32-bytes) || s
 // (32-bytes)` - `64 bytes`  (schnorr signature implemented by Zilliqa where both `r` and `s` are
-// scalars encoded as `32-bytes` values, most significant byte first.) * schnorr_poseidon: `r
-// (32-bytes) || s (32-bytes)` where s = Hash(1st pk || 2nd pk || r) - `64 bytes`  (schnorr
-// signature w/ Poseidon hash function implemented by O(1) Labs where both `r` and `s` are scalars
-// encoded as `32-bytes` values, least significant byte first.
+// scalars encoded as `32-bytes` values, most significant byte first.) * schnorr_bip340: `r
+// (32-bytes) || s (32-bytes)` - `64 bytes`  (sig = (bytes(R) || bytes((k + ed) mod n) where `r` is
+// the `X` coordinate of a point `R` whose `Y` coordinate is even, most significant bytes first.) *
+// schnorr_poseidon: `r (32-bytes) || s (32-bytes)` where s = Hash(1st pk || 2nd pk || r) - `64
+// bytes`  (schnorr signature w/ Poseidon hash function implemented by O(1) Labs where both `r` and
+// `s` are scalars encoded as `32-bytes` values, least significant byte first.
 // https://github.com/CodaProtocol/signer-reference/blob/master/schnorr.ml )
 type SignatureType string
 
@@ -33,5 +35,6 @@ const (
 	EcdsaRecovery   SignatureType = "ecdsa_recovery"
 	Ed25519         SignatureType = "ed25519"
 	Schnorr1        SignatureType = "schnorr_1"
+	SchnorrBip340   SignatureType = "schnorr_bip340"
 	SchnorrPoseidon SignatureType = "schnorr_poseidon"
 )

--- a/types/types.go
+++ b/types/types.go
@@ -18,5 +18,5 @@ const (
 	// RosettaAPIVersion is the version of the Rosetta API
 	// specification used to generate code for this release
 	// of the SDK.
-	RosettaAPIVersion = "1.4.12"
+	RosettaAPIVersion = "1.4.15"
 )


### PR DESCRIPTION
Fixes # .

### Motivation

Add support for Schnorr BIP-340 to `mesh-sdk-go`

### Solution

Update mesh specification to [1.4.15](https://github.com/coinbase/mesh-specifications/releases/tag/v1.4.15) as discussed in #500 

- adds BIP-340 support to `CurveType` and `SignatureType`

<!-- ### Open questions -->
<!--
(optional) Any open questions or feedback on design desired?
-->
