### PR TITLE
fix: add nil check to block asserter

### DIFF
--- a/asserter/block.go
+++ b/asserter/block.go
@@ -598,7 +598,7 @@ func (a *Asserter) Block(
 
 	// Only apply duplicate hash and index checks if the block index is not the
 	// genesis index.
-	if a.genesisBlock.Index != block.BlockIdentifier.Index {
+	if a.genesisBlock == nil || a.genesisBlock.Index != block.BlockIdentifier.Index {
 		if block.BlockIdentifier.Hash == block.ParentBlockIdentifier.Hash {
 			return ErrBlockHashEqualsParentBlockHash
 		}


### PR DESCRIPTION
### Motivation
Configuring a generic Asserter without a genesis block results in a nil pointer exception on this line.

### Solution
Add a nil check