### PR TITLE
chore: add unit tests to headerforwarder package

### DIFF
--- a/headerforwarder/forwarder.go
+++ b/headerforwarder/forwarder.go
@@ -263,7 +263,15 @@ func (hf *HeaderForwarder) RoundTrip(req *http.Request) (*http.Response, error) 
 	return resp, err
 }
 
-func (hf *HeaderForwarder) UnaryClientInterceptor(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+func (hf *HeaderForwarder) UnaryClientInterceptor(
+	ctx context.Context,
+	method string,
+	req,
+	reply interface{},
+	cc *grpc.ClientConn,
+	invoker grpc.UnaryInvoker,
+	opts ...grpc.CallOption,
+) error {
 	// Capture incoming headers from the grpc call
 	header := make(metadata.MD)
 	opts = append(opts, grpc.Header(&header))

--- a/headerforwarder/forwarder.go
+++ b/headerforwarder/forwarder.go
@@ -132,7 +132,14 @@ func (hf *HeaderForwarder) rememberHeaders(req *http.Request, resp *http.Respons
 
 	// Only remember interesting headers
 	for _, interestingHeader := range hf.interestingHeaders {
-		headersToRemember.Set(interestingHeader, resp.Header.Get(interestingHeader))
+		values := resp.Header.Values(interestingHeader)
+
+		// Only remember the header if it is not empty
+		if len(values) > 0 {
+			for _, v := range values {
+				headersToRemember.Add(interestingHeader, v)
+			}
+		}
 	}
 
 	hf.incomingHeaderLock.Lock()
@@ -176,7 +183,7 @@ func (hf *HeaderForwarder) rememberMetadata(ctx context.Context, resp metadata.M
 
 	for _, interestingHeader := range hf.interestingHeaders {
 		for _, value := range resp.Get(strings.ToLower(interestingHeader)) {
-			headersToRemember.Set(interestingHeader, value)
+			headersToRemember.Add(interestingHeader, value)
 		}
 	}
 
@@ -187,7 +194,7 @@ func (hf *HeaderForwarder) rememberMetadata(ctx context.Context, resp metadata.M
 
 // GetResponseHeaders returns any headers that should be returned to a rosetta response. These
 // consist of native node response headers/metadata that were remembered for a request ID.
-func (hf *HeaderForwarder) getResponseHeaders(rosettaRequestID string) (http.Header, bool) {
+func (hf *HeaderForwarder) GetResponseHeaders(rosettaRequestID string) (http.Header, bool) {
 	hf.incomingHeaderLock.RLock()
 	headers, ok := hf.incomingHeaders[rosettaRequestID]
 	hf.incomingHeaderLock.RUnlock()
@@ -223,7 +230,7 @@ func (hf *HeaderForwarder) HeaderForwarderHandler(next http.Handler) http.Handle
 		wrappedResponseWriter := NewResponseWriter(
 			w,
 			RosettaIDFromRequest(requestWithID),
-			hf.getResponseHeaders,
+			hf.GetResponseHeaders,
 		)
 
 		// Serve the request
@@ -258,7 +265,7 @@ func (hf *HeaderForwarder) RoundTrip(req *http.Request) (*http.Response, error) 
 
 func (hf *HeaderForwarder) UnaryClientInterceptor(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 	// Capture incoming headers from the grpc call
-	var header metadata.MD
+	header := make(metadata.MD)
 	opts = append(opts, grpc.Header(&header))
 
 	// Get outgoing headers from the request ID in context

--- a/headerforwarder/forwarder_test.go
+++ b/headerforwarder/forwarder_test.go
@@ -1,0 +1,409 @@
+package headerforwarder
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+var defaultInterestingHeaders = []string{
+	"X-Client-Id",
+	"X-Client-Type",
+}
+
+//
+// Helpers/Mocks
+//
+
+// for whatever reason this isn't allowed to be named mockTransport
+type fakeTransport struct {
+	LastRequest *http.Request
+	response    *http.Response
+	err         error
+}
+
+func (f *fakeTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	f.LastRequest = r
+	return f.response, f.err
+}
+
+func newMockTransport(incomingHeaders http.Header, err error) http.RoundTripper {
+	resp := &http.Response{
+		Header: incomingHeaders,
+	}
+
+	return &fakeTransport{
+		response: resp,
+		err:      err,
+	}
+}
+
+type mockInvoker struct {
+	LastRequestMD metadata.MD
+	responseMD    metadata.MD
+	err           error
+}
+
+func (m *mockInvoker) Invoke(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+	m.LastRequestMD, _ = metadata.FromOutgoingContext(ctx)
+
+	// add response metadata to pointer from call option
+	var headerOpt grpc.HeaderCallOption
+	for _, opt := range opts {
+		if o, ok := opt.(grpc.HeaderCallOption); ok {
+			headerOpt = o
+		}
+	}
+
+	for k, v := range m.responseMD {
+		headerOpt.HeaderAddr.Append(k, v...)
+	}
+
+	return m.err
+}
+
+func newMockInvoker(responseMD metadata.MD, err error) *mockInvoker {
+	return &mockInvoker{
+		err:        err,
+		responseMD: responseMD,
+	}
+}
+
+func contextWithID() (context.Context, string) {
+	ctx := ContextWithRosettaID(context.Background())
+	return ctx, RosettaIDFromContext(ctx)
+}
+
+func newRequest(ctx context.Context, header http.Header) *http.Request {
+	req := &http.Request{}
+
+	if header == nil {
+		req.Header = make(http.Header)
+	} else {
+		req.Header = header
+	}
+
+	return req.WithContext(ctx)
+}
+
+type mockHandler struct {
+	LastRequestID string
+}
+
+func (m *mockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	m.LastRequestID = RosettaIDFromRequest(r)
+}
+
+//
+// Tests
+//
+
+func TestRoundTrip(t *testing.T) {
+	tests := map[string]struct {
+		interestingHeaders []string
+		// a mock for headers already captured from a rosetta request by the forwarder
+		outgoingHeaders http.Header
+		// a mock for headers coming from a native node response to the forwarder
+		incomingHeaders http.Header
+
+		ExpectedError error
+		// expected headers on the request sent to the native node
+		ExpectedRequestHeaders http.Header
+		// expected headers to be captured from the native node response
+		ExpectedResponseHeaders http.Header
+	}{
+		"calls actual transport": {
+			ExpectedError: nil,
+		},
+
+		"adds outgoing header to request": {
+			outgoingHeaders: map[string][]string{
+				"X-Client-Id": {"test"},
+			},
+			ExpectedRequestHeaders: map[string][]string{
+				"X-Client-Id": {"test"},
+			},
+		},
+
+		"adds multiple outgoing headers to request": {
+			outgoingHeaders: map[string][]string{
+				"X-Client-Id":   {"test"},
+				"X-Client-Type": {"testclient"},
+			},
+			ExpectedRequestHeaders: map[string][]string{
+				"X-Client-Id":   {"test"},
+				"X-Client-Type": {"testclient"},
+			},
+		},
+
+		"adds outgoing header with multiple values to request": {
+			outgoingHeaders: map[string][]string{
+				"X-Client-Id": {"test", "test2"},
+			},
+			ExpectedRequestHeaders: map[string][]string{
+				"X-Client-Id": {"test", "test2"},
+			},
+		},
+
+		"captures headers from response": {
+			incomingHeaders: map[string][]string{
+				"X-Client-Id":  {"test", "test2"},
+				"Content-Type": {"application/json"},
+			},
+			ExpectedResponseHeaders: map[string][]string{
+				"X-Client-Id": {"test", "test2"},
+			},
+		},
+
+		"captures no headers if none are interesting": {
+			interestingHeaders: []string{},
+			incomingHeaders: map[string][]string{
+				"X-Client-Id":  {"test", "test2"},
+				"Content-Type": {"application/json"},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			// default values because http Request always have a non-nil Header
+			// We don't need to do this for expected response because it's compared to the
+			// internal headers map in HeaderForwarder, which is nil if no headers are captured
+			if test.ExpectedRequestHeaders == nil {
+				test.ExpectedRequestHeaders = make(http.Header)
+			}
+
+			// for convenience we use default interesting headers
+			if test.interestingHeaders == nil {
+				test.interestingHeaders = defaultInterestingHeaders
+			}
+
+			ctx, requestID := contextWithID()
+			mockTransport := newMockTransport(test.incomingHeaders, nil)
+
+			hf := &HeaderForwarder{
+				interestingHeaders: test.interestingHeaders,
+				incomingHeaders:    make(map[string]http.Header),
+				actualTransport:    mockTransport,
+				outgoingHeaders: map[string]http.Header{
+					requestID: test.outgoingHeaders,
+				},
+			}
+
+			testReq := newRequest(ctx, nil)
+
+			_, err := hf.RoundTrip(testReq)
+			assert.Equal(t, test.ExpectedError, err)
+
+			outgoingReq := mockTransport.(*fakeTransport).LastRequest
+			capturedHeaders, _ := hf.GetResponseHeaders(requestID)
+
+			assert.Equal(t, test.ExpectedRequestHeaders, outgoingReq.Header)
+			assert.Equal(t, test.ExpectedResponseHeaders, capturedHeaders)
+		})
+	}
+}
+
+func TestUnaryClientInterceptor(t *testing.T) {
+	tests := map[string]struct {
+		interestingHeaders []string
+		// a mock for headers already captured from a rosetta request by the forwarder
+		outgoingHeaders http.Header
+		// a mock for headers coming from a native node response to the forwarder
+		incomingMD metadata.MD
+
+		ExpectedError error
+		// expected headers on the request sent to the native node
+		ExpectedRequestMD metadata.MD
+		// expected headers to be captured from the native node response
+		ExpectedResponseHeaders http.Header
+	}{
+		"calls invoker": {},
+
+		"adds outgoing headers to context": {
+			outgoingHeaders: map[string][]string{
+				"X-Client-Id": {"test"},
+			},
+			ExpectedRequestMD: map[string][]string{
+				"x-client-id": {"test"},
+			},
+		},
+
+		"adds multiple outgoing headers to context": {
+			outgoingHeaders: map[string][]string{
+				"X-Client-Id":   {"test"},
+				"X-Client-Type": {"testclient"},
+			},
+			ExpectedRequestMD: map[string][]string{
+				"x-client-id":   {"test"},
+				"x-client-type": {"testclient"},
+			},
+		},
+
+		"adds outgoing header with multiple values to context": {
+			outgoingHeaders: map[string][]string{
+				"X-Client-Id": {"test", "test2"},
+			},
+			ExpectedRequestMD: map[string][]string{
+				"x-client-id": {"test", "test2"},
+			},
+		},
+
+		"captures headers from response metadata": {
+			incomingMD: map[string][]string{
+				"x-client-id":  {"test", "test2"},
+				"content-type": {"application/json"},
+			},
+			ExpectedResponseHeaders: map[string][]string{
+				"X-Client-Id": {"test", "test2"},
+			},
+		},
+
+		"captures headers with multiple values from response metadata": {
+			incomingMD: map[string][]string{
+				"x-client-id":  {"test", "test2"},
+				"content-type": {"application/json"},
+			},
+			ExpectedResponseHeaders: map[string][]string{
+				"X-Client-Id": {"test", "test2"},
+			},
+		},
+
+		"captures no headers if none are interesting": {
+			interestingHeaders: []string{},
+			incomingMD: map[string][]string{
+				"X-Client-Id":  {"test", "test2"},
+				"Content-Type": {"application/json"},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			// for convenience we use default interesting headers
+			if test.interestingHeaders == nil {
+				test.interestingHeaders = defaultInterestingHeaders
+			}
+
+			ctx, requestID := contextWithID()
+
+			mock := newMockInvoker(test.incomingMD, nil)
+
+			hf := &HeaderForwarder{
+				interestingHeaders: test.interestingHeaders,
+				incomingHeaders:    make(map[string]http.Header),
+				actualTransport:    nil,
+				outgoingHeaders: map[string]http.Header{
+					requestID: test.outgoingHeaders,
+				},
+			}
+
+			err := hf.UnaryClientInterceptor(ctx, "test", nil, nil, nil, mock.Invoke)
+			assert.Nil(t, err)
+
+			outgoingReqMD := mock.LastRequestMD
+			capturedHeaders, _ := hf.GetResponseHeaders(requestID)
+
+			assert.Equal(t, test.ExpectedRequestMD, outgoingReqMD)
+			assert.Equal(t, test.ExpectedResponseHeaders, capturedHeaders)
+		})
+	}
+}
+
+func TestHeaderForwarderHandler(t *testing.T) {
+	tests := map[string]struct {
+		interestingHeaders []string
+		// a mock for headers on the rosetta request
+		requestHeaders http.Header
+
+		// expected headers to be captured from the rosetta request
+		ExpectedOutgoingHeaders http.Header
+	}{
+		"calls next handler": {},
+
+		"adds request ID to context": {},
+
+		"captures request headers": {
+			requestHeaders: map[string][]string{
+				"X-Client-Id":  {"test"},
+				"Content-Type": {"application/json"},
+			},
+			ExpectedOutgoingHeaders: map[string][]string{
+				"X-Client-Id": {"test"},
+			},
+		},
+
+		"captures multiple request headers": {
+			requestHeaders: map[string][]string{
+				"X-Client-Id":  {"test"},
+				"Content-Type": {"application/json"},
+			},
+			ExpectedOutgoingHeaders: map[string][]string{
+				"X-Client-Id": {"test"},
+			},
+		},
+
+		"captures request headers with multiple values": {
+			requestHeaders: map[string][]string{
+				"X-Client-Id":  {"test"},
+				"Content-Type": {"application/json"},
+			},
+			ExpectedOutgoingHeaders: map[string][]string{
+				"X-Client-Id": {"test"},
+			},
+		},
+
+		"captures no headers if none are interesting": {
+			interestingHeaders: []string{},
+			requestHeaders: map[string][]string{
+				"X-Client-Id":  {"test"},
+				"Content-Type": {"application/json"},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			// default values because http Request always have a non-nil Header
+			if test.ExpectedOutgoingHeaders == nil {
+				test.ExpectedOutgoingHeaders = make(http.Header)
+			}
+
+			if test.interestingHeaders == nil {
+				test.interestingHeaders = defaultInterestingHeaders
+			}
+
+			mockHandler := &mockHandler{}
+			r := &http.Request{
+				Header: test.requestHeaders,
+			}
+			w := httptest.NewRecorder()
+
+			hf := &HeaderForwarder{
+				interestingHeaders: test.interestingHeaders,
+				incomingHeaders:    make(map[string]http.Header),
+				outgoingHeaders:    make(map[string]http.Header),
+				actualTransport:    nil,
+			}
+
+			handler := hf.HeaderForwarderHandler(mockHandler)
+			handler.ServeHTTP(w, r)
+
+			requestID := mockHandler.LastRequestID
+			assert.NotEmpty(t, requestID)
+
+			// Check that the uuid can be parsed. We don't actually care about this
+			// we just care that it's a string that looks like a uuid and this is easy
+			_, err := uuid.Parse(requestID)
+			assert.Nil(t, err)
+
+			assert.Equal(t, test.ExpectedOutgoingHeaders, hf.outgoingHeaders[requestID])
+		})
+	}
+}

--- a/headerforwarder/forwarder_test.go
+++ b/headerforwarder/forwarder_test.go
@@ -64,7 +64,14 @@ type mockInvoker struct {
 	err           error
 }
 
-func (m *mockInvoker) Invoke(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+func (m *mockInvoker) Invoke(
+	ctx context.Context,
+	method string,
+	req,
+	reply interface{},
+	cc *grpc.ClientConn,
+	opts ...grpc.CallOption,
+) error {
 	m.LastRequestMD, _ = metadata.FromOutgoingContext(ctx)
 
 	// add response metadata to pointer from call option
@@ -212,8 +219,10 @@ func TestRoundTrip(t *testing.T) {
 
 			testReq := newRequest(ctx, nil)
 
-			_, err := hf.RoundTrip(testReq)
+			response, err := hf.RoundTrip(testReq)
 			assert.Equal(t, test.ExpectedError, err)
+
+			defer response.Body.Close()
 
 			outgoingReq := mockTransport.(*fakeTransport).LastRequest
 			capturedHeaders, _ := hf.GetResponseHeaders(requestID)

--- a/headerforwarder/forwarder_test.go
+++ b/headerforwarder/forwarder_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package headerforwarder
 
 import (

--- a/headerforwarder/response_writer.go
+++ b/headerforwarder/response_writer.go
@@ -23,6 +23,7 @@ import (
 // responses, and set on the rosetta response.
 type ResponseWriter struct {
 	writer               http.ResponseWriter
+	calledWriteHeaders   bool
 	RosettaRequestID     string
 	GetAdditionalHeaders func(string) (http.Header, bool)
 }
@@ -46,11 +47,16 @@ func (hfrw *ResponseWriter) Header() http.Header {
 
 // Write passes through to the underlying ResponseWriter instance
 func (hfrw *ResponseWriter) Write(b []byte) (int, error) {
+	if !hfrw.calledWriteHeaders {
+		hfrw.AddExtractedHeaders()
+	}
+
 	return hfrw.writer.Write(b)
 }
 
 // WriteHeader will add any final extracted headers, and then pass through to the underlying ResponseWriter instance
 func (hfrw *ResponseWriter) WriteHeader(statusCode int) {
+	hfrw.calledWriteHeaders = true
 	hfrw.AddExtractedHeaders()
 	hfrw.writer.WriteHeader(statusCode)
 }

--- a/headerforwarder/response_writer_test.go
+++ b/headerforwarder/response_writer_test.go
@@ -62,7 +62,8 @@ func TestWriteAddsHeaders(t *testing.T) {
 	writer := httptest.NewRecorder()
 	hfrw := NewResponseWriter(writer, "test-id", mockGetter("test-id", mockHeader))
 
-	hfrw.Write([]byte("test-bytes"))
+	_, err := hfrw.Write([]byte("test-bytes"))
+	assert.Nil(t, err)
 
 	result := writer.Result()
 	assert.Equal(t, 200, result.StatusCode)

--- a/headerforwarder/response_writer_test.go
+++ b/headerforwarder/response_writer_test.go
@@ -43,6 +43,7 @@ func TestWriteHeader(t *testing.T) {
 	hfrw.WriteHeader(200)
 
 	result := writer.Result()
+	defer result.Body.Close()
 	assert.Equal(t, 200, result.StatusCode)
 }
 
@@ -53,6 +54,7 @@ func TestWriteHeaderAddsHeaders(t *testing.T) {
 	hfrw.WriteHeader(200)
 
 	result := writer.Result()
+	defer result.Body.Close()
 	assert.Equal(t, 200, result.StatusCode)
 	assert.Equal(t, mockHeader.Values("test-header"), result.Header.Values("test-header"))
 }
@@ -66,6 +68,7 @@ func TestWriteAddsHeaders(t *testing.T) {
 	assert.Nil(t, err)
 
 	result := writer.Result()
+	defer result.Body.Close()
 	assert.Equal(t, 200, result.StatusCode)
 	assert.Equal(t, mockHeader.Values("test-header"), result.Header.Values("test-header"))
 }

--- a/headerforwarder/response_writer_test.go
+++ b/headerforwarder/response_writer_test.go
@@ -1,0 +1,56 @@
+package headerforwarder
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func mockGetter(id string, headers http.Header) func(string) (http.Header, bool) {
+	return func(s string) (http.Header, bool) {
+		if s != id {
+			return nil, false
+		}
+
+		return headers, true
+	}
+}
+
+var mockHeader http.Header = http.Header{
+	"Test-Header": []string{"test-value"},
+}
+
+func TestWriteHeader(t *testing.T) {
+	writer := httptest.NewRecorder()
+	hfrw := NewResponseWriter(writer, "test-id", mockGetter("test-id", mockHeader))
+
+	hfrw.WriteHeader(200)
+
+	result := writer.Result()
+	assert.Equal(t, 200, result.StatusCode)
+}
+
+func TestWriteHeaderAddsHeaders(t *testing.T) {
+	writer := httptest.NewRecorder()
+	hfrw := NewResponseWriter(writer, "test-id", mockGetter("test-id", mockHeader))
+
+	hfrw.WriteHeader(200)
+
+	result := writer.Result()
+	assert.Equal(t, 200, result.StatusCode)
+	assert.Equal(t, mockHeader.Values("test-header"), result.Header.Values("test-header"))
+}
+
+// Tests that headers are written if Write is called before WriteHeader
+func TestWriteAddsHeaders(t *testing.T) {
+	writer := httptest.NewRecorder()
+	hfrw := NewResponseWriter(writer, "test-id", mockGetter("test-id", mockHeader))
+
+	hfrw.Write([]byte("test-bytes"))
+
+	result := writer.Result()
+	assert.Equal(t, 200, result.StatusCode)
+	assert.Equal(t, mockHeader.Values("test-header"), result.Header.Values("test-header"))
+}

--- a/headerforwarder/response_writer_test.go
+++ b/headerforwarder/response_writer_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package headerforwarder
 
 import (


### PR DESCRIPTION
### Motivation
This utility was part of a proof-of-concept and this is an attempt to move it closer to a production-ready state

### Solution
`HeaderForwarder` and `headerforwarder.ResponseWriter` were not tested, lacking specific code/documentation about edge cases

This PR adds those tests and fixes some issues uncovered by the testing