### PR TITLE
Update mesh-specification version to 1.5.1

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -41,7 +41,7 @@ var (
 	ErrRetriable = errors.New("retriable http status code received")
 )
 
-// APIClient manages communication with the Rosetta API v1.4.13
+// APIClient manages communication with the Rosetta API v1.5.1
 // In most cases there should be only one, shared, APIClient.
 type APIClient struct {
 	cfg    *Configuration

--- a/codegen.sh
+++ b/codegen.sh
@@ -50,7 +50,7 @@ done
 rm -rf tmp
 
 # Download spec file from releases
-ROSETTA_SPEC_VERSION=1.4.15
+ROSETTA_SPEC_VERSION=1.5.1
 curl -L https://github.com/coinbase/rosetta-specifications/releases/download/v${ROSETTA_SPEC_VERSION}/api.json -o api.json
 
 # Generate client + types code

--- a/types/types.go
+++ b/types/types.go
@@ -18,5 +18,5 @@ const (
 	// RosettaAPIVersion is the version of the Rosetta API
 	// specification used to generate code for this release
 	// of the SDK.
-	RosettaAPIVersion = "1.4.15"
+	RosettaAPIVersion = "1.5.1"
 )


### PR DESCRIPTION
This synchronizes the un-updated api.json to be the correct version (see how it's 1.4.13 on the previous 1.4.15 version)